### PR TITLE
Enable OPCache

### DIFF
--- a/.ansible/playbooks/roles/symfony_vars/defaults/main.yml
+++ b/.ansible/playbooks/roles/symfony_vars/defaults/main.yml
@@ -69,6 +69,7 @@ cops_symfony_php_max_workers: "10"
 cops_symfony_php_max_spare_workers: "5"
 cops_symfony_php_min_spare_workers: "3"
 cops_symfony_php_apcu_enabled: "1"
+cops_symfony_php_opcache_enabled: "1"
 cops_symfony_docker_env_freeform: |-
   {{ cops_symfony_docker_env_defaults}}
   {{ cops_symfony_docker_env_extra}}
@@ -94,7 +95,8 @@ cops_symfony_docker_env_defaults: |-
   PHP_MAX_WORKERS={{ cops_symfony_php_max_workers }}
   PHP_MAX_SPARE_WORKERS={{ cops_symfony_php_max_spare_workers }}
   PHP_MIN_SPARE_WORKERS={{ cops_symfony_php_min_spare_workers }}
-  PHP_APCU_ENABLED={{cops_symfony_php_apcu_enabled}}
+  PHP_APCU_ENABLED={{ cops_symfony_php_apcu_enabled }}
+  PHP_OPCACHE_ENABLED={{ cops_symfony_php_opcache_enabled }}
   PROJECT_ENV={{ cops_symfony_project_env }}
   # cors
   SYMFONY__CORS_ORIGIN_WHITELIST={{cops_symfony_hosts_whitelist}}

--- a/sys/etc/php.d/10-opcache.ini.frep
+++ b/sys/etc/php.d/10-opcache.ini.frep
@@ -1,23 +1,20 @@
+{{ $apcu_enabled := .Env.PHP_OPCACHE_ENABLED | default "1" }}
+{{ if eq $apcu_enabled "1" }}
 zend_extension=opcache
 opcache.enable=1
 opcache.enable_cli=1
-
 ; Memory in MB
 opcache.memory_consumption=128
 ; Memory in MB
 opcache.interned_strings_buffer=8
-
 ; Absolute number
 opcache.max_accelerated_files=4000
-
 ; 0 = deactivate, 1 = activate
 opcache.validate_timestamps=1
 ; seconds, 0 = always
 ; opcache.revalidate_freq=2
-
 ; Bitflags, all to 1 = everything enabled
 ; opcache.optimization_level=0xffffffff
-
 ; Site in bytes, 0 = no limit
 opcache.max_file_size=0
-
+{{ end }}

--- a/sys/etc/php.d/10-opcache.ini.frep
+++ b/sys/etc/php.d/10-opcache.ini.frep
@@ -1,0 +1,23 @@
+zend_extension=opcache
+opcache.enable=1
+opcache.enable_cli=1
+
+; Memory in MB
+opcache.memory_consumption=128
+; Memory in MB
+opcache.interned_strings_buffer=8
+
+; Absolute number
+opcache.max_accelerated_files=4000
+
+; 0 = deactivate, 1 = activate
+opcache.validate_timestamps=1
+; seconds, 0 = always
+; opcache.revalidate_freq=2
+
+; Bitflags, all to 1 = everything enabled
+; opcache.optimization_level=0xffffffff
+
+; Site in bytes, 0 = no limit
+opcache.max_file_size=0
+

--- a/sys/etc/php.d/10-opcache.ini.frep
+++ b/sys/etc/php.d/10-opcache.ini.frep
@@ -1,5 +1,5 @@
-{{ $apcu_enabled := .Env.PHP_OPCACHE_ENABLED | default "1" }}
-{{ if eq $apcu_enabled "1" }}
+{{ $opcache_enabled := .Env.PHP_OPCACHE_ENABLED | default "1" }}
+{{ if eq $opcache_enabled "1" }}
 zend_extension=opcache
 opcache.enable=1
 opcache.enable_cli=1


### PR DESCRIPTION
Not enabling it should never happen.

With a Symfony app, on dev+debug mode, got a 2x improvement (from 800ms avg. to 450ms avg. on home page), on prod mode got a 5x improvement (from 500ms avg. to 90ms avg.).